### PR TITLE
Update tlbc image to release27370

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # DAppNodeSDK release directories
 build_*
+/.idea

--- a/build-node/Dockerfile
+++ b/build-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM trustlines/tlbc-node:release24493
+FROM trustlines/tlbc-node:release27370
 
 WORKDIR /config/custom/keys/tlbc
 

--- a/build-node/start_trustlines.sh
+++ b/build-node/start_trustlines.sh
@@ -26,8 +26,8 @@ if [ "$ROLE" == "validator" ]; then
         echo "#####################################################################################################"
         while true; do sleep 5; done
     else
-        /home/parity/parity_wrapper.sh --role $ROLE --address $ADDRESS --parity-args $PARITY_ARGS
+        /home/openethereum/client_wrapper.sh --role $ROLE --address $ADDRESS --client-args $CLIENT_ARGS
     fi
 else
-    /home/parity/parity_wrapper.sh --role $ROLE --parity-args $PARITY_ARGS
+    /home/openethereum/client_wrapper.sh --role $ROLE --client-args $CLIENT_ARGS
 fi

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "trustlines.dnp.dappnode.eth",
   "version": "1.0.0",
-  "upstreamVersion": "release21542",
+  "upstreamVersion": "release27370",
   "shortDescription": "Financial inclusion through OS decentralized systems",
   "description": "Trustlines node to participate and securitize the network.\n\nThe Trustlines Protocol aims to provide the service of “transfer of value” without actually transferring value. This can be accomplished by leveraging networks of mutual-trust. The Trustlines Protocol is being built to support a range of use cases by leveraging existing networks of mutual trust and mapping trust-based relationships onto trustless infrastructure",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ROLE=observer
       - ADDRESS=
       - PASSWORD=
-      - PARITY_ARGS=
+      - CLIENT_ARGS=
     restart: unless-stopped
     ports:
       - "30302"


### PR DESCRIPTION
I'm not sure how you build the images and whether the node image   node: image: "node.trustlines.dnp.dappnode.eth:1.0.0" - should maybe be changed to 1.0.1? But this must be something in your release pipline and since there is no documentation in the repo I've left it like this. 

Note that I change $PARITY_ARGS to $CLIENT_ARGS as we are now using OE and not parity.


**Also important**

We are currently experiencing a fork and validators end up on the wrong chain. Even after updating their chainspec file.
It looks like a bug/feature of OpenEtehreum. Since validators didn't receive the correct chainspec they were on a different chain, unfortunately even after applying the correct chainspec OE seems to think that they are on the correct chain, as the chains is maybe the longest.

What helped to get those unstuck nodes on the correct chain was to drop the open ethereum database and let the nodes resync. Then they end up on the correct chain.